### PR TITLE
Use 'routes.draw' instead of 'add_routes'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   devise_for :spree_user,
              class_name: Spree::User,
              only: [:omniauth_callbacks],


### PR DESCRIPTION
Replace `Spree::Core::Engine.add_routes` with `Spree::Core::Engine.routes.draw` in order to avoid deprecation warning.