### PR TITLE
Fix add `devise :omniauthable` to `Spree::User`

### DIFF
--- a/lib/solidus_social/engine.rb
+++ b/lib/solidus_social/engine.rb
@@ -16,6 +16,16 @@ module SolidusSocial
       Spree::SocialConfig = Spree::SocialConfiguration.new
     end
 
+    initializer 'solidus_social.decorate_spree_user' do
+      next unless Rails.application.respond_to?(:reloader)
+
+      Rails.application.reloader.after_class_unload do
+        # Reload and decorate the spree user class immediately after it is
+        # unloaded so that it is available to devise when loading routes
+        load File.join(__dir__, '../../app/models/spree/user_decorator.rb')
+      end
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)


### PR DESCRIPTION
Fix #20 

## Problem:
Devise error when 'hot' reloading code.

## Cause:
Rails 5 constant reloading loads routes before running the application
to_prepare block.

Solidus Social defines omniauth routes via devise which requires
Spree::User to have the `:omniauthable` attributes.

Our application and many gems apply their solidus
decorators from within the to_prepare block. This was the case for
solidus social decorating Spree::User to include the :omniauthable
attribute.

When rails would attempt to reload the environment constants, it would
unload the spree user constant (removing any previous decorations) and
then attempt to generate routes for (including the omniauth routes
defined in solidus_social). At this time, an error would be thrown since
the Spree::User class was missing the decorator required to draw these
routes.

## Solution:
Add an initializer which forces the solidus_social user decorator to be
loaded immediately after rails unloads existing constants during the
constant reload process.

## Testing:
1. To see the error checkout master and run `bundle exec rails c` (in the
  dummy store)
2. once in the pry environment run `reload!`
3. You should see the error

4. Checkout this branch
5. repeat the steps above
6. You should not receive any errors and be able to reload the rails
  environment