### PR TITLE
Fix displaying social link in new solidus version

### DIFF
--- a/app/overrides/add_authentications_to_account_summary.rb
+++ b/app/overrides/add_authentications_to_account_summary.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(virtual_path: 'spree/users/show',
                      name: 'add_socials_to_account_summary',
-                     insert_after: '[data-hook="admin_settings_sub_tabs"]',
+                     insert_after: '[data-hook="account_my_orders"]',
                      partial: 'spree/users/social',
                      disabled: false)

--- a/app/overrides/add_authentications_to_account_summary.rb
+++ b/app/overrides/add_authentications_to_account_summary.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(virtual_path: 'spree/users/show',
                      name: 'add_socials_to_account_summary',
-                     insert_after: '[data-hook="account_my_orders"]',
+                     insert_after: '[data-hook="admin_settings_sub_tabs"]',
                      partial: 'spree/users/social',
                      disabled: false)

--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(virtual_path: 'spree/admin/shared/_tabs',
+Deface::Override.new(virtual_path: 'spree/admin/shared/_settings_sub_menu',
                      name: 'add_social_providers_link_configuration_menu',
                      insert_bottom: '[data-hook="admin_settings_sub_tabs"]',
                      text: '<%= configurations_sidebar_menu_item Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %>',

--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -1,5 +1,5 @@
-Deface::Override.new(virtual_path: 'spree/admin/shared/_configuration_menu',
+Deface::Override.new(virtual_path: 'spree/admin/shared/_tabs',
                      name: 'add_social_providers_link_configuration_menu',
-                     insert_bottom: '[data-hook="admin_configurations_sidebar_menu"]',
+                     insert_bottom: '[data-hook="admin_settings_sub_tabs"]',
                      text: '<%= configurations_sidebar_menu_item Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %>',
                      disabled: false)

--- a/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -1,4 +1,3 @@
 <tr>
   <td><%= link_to Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %></td>
-  <td><%= Spree.t(:social_authentication_methods_description) %></td>
 </tr>

--- a/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -1,3 +1,0 @@
-<tr>
-  <td><%= link_to Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %></td>
-</tr>


### PR DESCRIPTION
Change data-hook to be compatible with new settings version.
Remove unnecessary file which breaks view