### PR TITLE
Enable PhantomJS disk cache

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,7 +8,12 @@ RSpec.configure do |config|
 
   Capybara.javascript_driver = :poltergeist
   Capybara.register_driver(:poltergeist) do |app|
-    Capybara::Poltergeist::Driver.new app, js_errors: true, timeout: 60
+    Capybara::Poltergeist::Driver.new(
+      app,
+      js_errors: true,
+      timeout: 60,
+      phantomjs_options: ["--disk-cache=true"]
+    )
   end
 
   config.before(:each, :js) do


### PR DESCRIPTION
Unfortunately there is a bug in PhantomJS where redirects and caching down play
nice together and result in the Poltergeist/PhantomJS forgetting all about the
page it was supposed to have just loaded and reporting a blank document.

Because this bug exists only in the in-memory cache, we can just enable the disk
cache to get around it. Eventually when people's OS package managers begin
shipping versions of PhantomJS where this issue is fixed. For now, Ubuntu is too
far behind, so we might as well leave this on this setting which should work for
all users.

Bug: https://github.com/teampoltergeist/poltergeist/issues/754