### PR TITLE
Remove partial that overrides solidus

### DIFF
--- a/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -1,4 +1,0 @@
-<tr>
-  <td><%= link_to Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %></td>
-  <td><%= Spree.t(:social_authentication_methods_description) %></td>
-</tr>


### PR DESCRIPTION
Fix issue #30.

The file `app/views/spree/admin/shared/_configuration_menu.html.erb`
exists in solidus codebase as well, so what happened here is that
the file was overriding solidus' one, with the nasty side effect
of not allowing other solidus plugins to show their configuration
tabs.