### PR TITLE
Allow Any OAuth Provider to set email

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -4,7 +4,7 @@ Spree.user_class.class_eval do
   devise :omniauthable
 
   def apply_omniauth(omniauth)
-    if %w(facebook google_oauth2).include? omniauth['provider']
+    if omniauth.fetch('info', {})['email'].present?
       self.email = omniauth['info']['email'] if email.blank?
     end
     user_authentications.build(provider: omniauth['provider'], uid: omniauth['uid'])

--- a/spec/models/spree/user_decorator_spec.rb
+++ b/spec/models/spree/user_decorator_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe Spree::User, type: :model do
         expect(user.email).to eq 'test@example.com'
       end
     end
+
+    context 'instance is valid' do
+      let(:user) { create(:user) { |user| user.email = nil } }
+      let(:omni_params) do
+        {
+          'provider' => 'any_provider',
+          'uid' => 12_345,
+          'info' => { 'email' => 'test@example.com' }
+        }
+      end
+
+      before do
+        allow(auths).to receive(:build)
+        allow(auths).to receive(:empty?).and_return(false)
+      end
+
+      it 'builds a valid user' do
+        user.apply_omniauth(omni_params)
+        expect(user.valid?).to be_truthy
+      end
+    end
   end
 
   context '.password_required?' do


### PR DESCRIPTION
Given a fresh install of solidus and a provider which is neither Facebook nor Google, User creation fails validation (email is not set).
Many providers yield an email address, so this change checks for the presence of an email address instead of the provider used.