### PR TITLE
Use the Application-Defined User Class instead of `Spree::User`

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -34,7 +34,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:notice] = I18n.t('devise.sessions.signed_in')
       redirect_back_or_default(account_url)
     else
-      user = Spree::User.find_by_email(auth_hash['info']['email']) || Spree::User.new
+      user = Spree.user_class.find_by_email(auth_hash['info']['email']) || Spree.user_class.new
       user.apply_omniauth(auth_hash)
       if user.save
         flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: auth_hash['provider'])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.routes.draw do
   devise_for :spree_user,
-             class_name: Spree::User,
+             class_name: Spree.user_class,
              only: [:omniauth_callbacks],
              controllers: { omniauth_callbacks: 'spree/omniauth_callbacks' },
              path: Spree::SocialConfig[:path_prefix]


### PR DESCRIPTION
not an issue in most cases, but seems like the right thing to do.

_(there are some failing tests, but they seem to be failing on the parent commit as well)_