### PR TITLE
add ffaker to test group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,11 @@ source "https://rubygems.org"
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+group :test do
+  if branch == 'master' || branch >= "v2.0"
+    gem "rails-controller-testing"
+  end
+  gem 'ffaker'
 end
 
 # hack for broken bundler dependency resolution


### PR DESCRIPTION
`ffaker` was removed as a runtime dependency of Solidus, but since in the [commit](https://github.com/solidusio/solidus/pull/2163/files) still try to load the gem will cause an error.

Adding the `ffaker` gem should fix that.