### PR TITLE
use https instead git protocol for get github sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 


### PR DESCRIPTION
using git protocol throws a warning about it's insecure, so use https instead.