### PR TITLE
there could be cases that build_resource is not called during a creat…

### DIFF
--- a/app/controllers/spree/user_registrations_controller_decorator.rb
+++ b/app/controllers/spree/user_registrations_controller_decorator.rb
@@ -10,6 +10,6 @@ Spree::UserRegistrationsController.class_eval do
   end
 
   def clear_omniauth
-    session[:omniauth] = nil unless @spree_user.new_record?
+    session[:omniauth] = nil unless @spree_user&.new_record?
   end
 end


### PR DESCRIPTION
…e method

and this will result in a fatal error:

NoMethodError - undefined method `new_record?' for nil:NilClass:

@jhawthorn do you think this make sense? This would prevent fatal errors.