### PR TITLE
Spec suite maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,12 @@ rvm:
   - 2.3.5
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: ruby
 dist: trusty
 addons:
   chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
+before_script:
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 rvm:
   - 2.3.5
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,12 @@ elsif branch >= "v2.0"
   gem 'rails', '~> 5.0.6'
 end
 
+if branch < 'v2.5'
+  gem 'factory_bot', '4.10.0'
+else
+  gem 'factory_bot', '> 4.10.0'
+end
+
 gem 'pg', '~> 0.21'
 gem 'mysql2', '~> 0.4.10'
 

--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -18,7 +18,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def omniauth_callback
     if request.env['omniauth.error'].present?
-      flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: auth_hash['provider'], reason: Spree.t(:user_was_not_valid))
+      flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: auth_hash['provider'], reason: I18n.t('spree.user_was_not_valid'))
       redirect_back_or_default(root_url)
       return
     end
@@ -41,7 +41,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         sign_in_and_redirect :spree_user, user
       else
         session[:omniauth] = auth_hash.except('extra')
-        flash[:notice] = Spree.t(:one_more_step, kind: auth_hash['provider'].capitalize)
+        flash[:notice] = I18n.t('spree.one_more_step', kind: auth_hash['provider'].capitalize)
         redirect_to new_spree_user_registration_url
         return
       end

--- a/app/controllers/spree/user_authentications_controller.rb
+++ b/app/controllers/spree/user_authentications_controller.rb
@@ -6,7 +6,7 @@ class Spree::UserAuthenticationsController < Spree::StoreController
   def destroy
     @authentication = spree_current_user.user_authentications.find(params[:id])
     @authentication.destroy
-    flash[:notice] = Spree.t(:destroy, scope: :authentications)
+    flash[:notice] = I18n.t('spree.destroy', scope: :authentications)
     redirect_to spree.account_path
   end
 end

--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(virtual_path: 'spree/admin/shared/_configuration_menu',
                      name: 'add_social_providers_link_configuration_menu',
                      insert_bottom: '[data-hook="admin_configurations_sidebar_menu"]',
-                     text: '<%= configurations_sidebar_menu_item Spree.t(:social_authentication_methods), spree.admin_authentication_methods_path %>',
+                     text: '<%= configurations_sidebar_menu_item I18n.t("spree.social_authentication_methods"), spree.admin_authentication_methods_path %>',
                      disabled: false)

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -10,7 +10,7 @@
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
       <%= f.field_container :provider do %>
-        <%= f.label :provider, Spree.t(:social_provider) %>
+        <%= f.label :provider, I18n.t('spree.social_provider') %>
         <%= f.select :provider, Spree::AuthenticationMethod.provider_options, {}, { include_blank: false, class: 'select2 fullwidth' } %>
       <% end %>
     </div>
@@ -18,11 +18,11 @@
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
       <%= f.field_container :active do %>
-        <span style="padding:0 10px 2px;"><%= f.label :active, Spree.t(:active) %></span>
+        <span style="padding:0 10px 2px;"><%= f.label :active, I18n.t('spree.active') %></span>
         <%= f.radio_button :active, :true %>
-        <span style="padding:0 2px;"><%= Spree.t(:say_yes) %></span>
+        <span style="padding:0 2px;"><%= I18n.t('spree.say_yes') %></span>
         <%= f.radio_button :active, :false %>
-        <span style="padding:0 2px"><%= Spree.t(:say_no) %></span>
+        <span style="padding:0 2px"><%= I18n.t('spree.say_no') %></span>
       <% end %>
     </div>
   </div>

--- a/app/views/spree/admin/authentication_methods/edit.html.erb
+++ b/app/views/spree/admin/authentication_methods/edit.html.erb
@@ -1,11 +1,11 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:edit_social_method) %>
+  <%= I18n.t('spree.edit_social_method') %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'icon-arrow-left', Spree.t(:back_to_authentication_methods_list), admin_authentication_methods_path, class: 'button' %></li>
+  <li><%= link_to_with_icon 'icon-arrow-left', I18n.t('spree.back_to_authentication_methods_list'), admin_authentication_methods_path, class: 'button' %></li>
 <% end %>
 
 <%= render 'spree/shared/error_messages', target: @authentication_method %>

--- a/app/views/spree/admin/authentication_methods/index.html.erb
+++ b/app/views/spree/admin/authentication_methods/index.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:social_authentication_methods) %>
+  <%= I18n.t('spree.social_authentication_methods') %>
 <% end %>
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
     <li>
-      <%= button_link_to Spree.t(:new_social_method), new_object_url, id: 'admin_new_slide_link' %>
+      <%= link_to I18n.t('spree.new_social_method'), new_object_url, id: 'admin_new_slide_link' %>
     </li>
   </ul>
 <% end %>
@@ -23,11 +23,11 @@
       <col style="width: 20%" />
     </colgroup>
     <thead data-hook="admin_social_methods_index_headers">
-      <th><%= Spree.t(:social_provider) %></th>
-      <th><%= Spree.t(:social_api_key) %></th>
-      <th><%= Spree.t(:social_api_secret) %></th>
+      <th><%= I18n.t('spree.social_provider') %></th>
+      <th><%= I18n.t('spree.social_api_key') %></th>
+      <th><%= I18n.t('spree.social_api_secret') %></th>
       <th><%= Spree.t(:environment) %></th>
-      <th><%= Spree.t(:active) %></th>
+      <th><%= I18n.t('spree.active') %></th>
       <th data-hook="admin_social_methods_index_header_actions" class="actions"></th>
     </thead>
     <tbody>
@@ -37,7 +37,7 @@
           <td class="align-center"><%= truncate method.api_key, length: 10 %></td>
           <td class="align-center"><%= truncate method.api_secret, length: 10 %></td>
           <td class="align-center"><%= method.environment.to_s.titleize %></td>
-          <td class="align-center"><%= method.active ? Spree.t(:yes) : Spree.t(:no) %></td>
+          <td class="align-center"><%= method.active ? I18n.t('spree.yes') : I18n.t('spree.no') %></td>
           <td class="actions">
             <%= link_to_edit method, no_text: true %>
             <%= link_to_delete method, no_text: true %>
@@ -48,7 +48,7 @@
   </table>
 <% else %>
   <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_authentication_methods_found) %>,
-    <%= Spree.t(:add_one) %>!
+    <%= I18n.t('spree.no_authentication_methods_found') %>,
+    <%= I18n.t('spree.add_one') %>!
   </div>
 <% end %>

--- a/app/views/spree/admin/authentication_methods/index.html.erb
+++ b/app/views/spree/admin/authentication_methods/index.html.erb
@@ -26,7 +26,7 @@
       <th><%= I18n.t('spree.social_provider') %></th>
       <th><%= I18n.t('spree.social_api_key') %></th>
       <th><%= I18n.t('spree.social_api_secret') %></th>
-      <th><%= Spree.t(:environment) %></th>
+      <th><%= I18n.t('spree.environment') %></th>
       <th><%= I18n.t('spree.active') %></th>
       <th data-hook="admin_social_methods_index_header_actions" class="actions"></th>
     </thead>

--- a/app/views/spree/admin/authentication_methods/new.html.erb
+++ b/app/views/spree/admin/authentication_methods/new.html.erb
@@ -1,11 +1,11 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:new_social_method) %>
+  <%= I18n.t('spree.new_social_method') %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'icon-arrow-left', Spree.t(:back_to_authentication_methods_list), admin_authentication_methods_path, class: 'button' %></li>
+  <li><%= link_to_with_icon 'icon-arrow-left', I18n.t('spree.back_to_authentication_methods_list'), admin_authentication_methods_path, class: 'button' %></li>
 <% end %>
 
 <%= render 'spree/shared/error_messages', target: @authentication_method %>

--- a/app/views/spree/shared/_social.html.erb
+++ b/app/views/spree/shared/_social.html.erb
@@ -1,11 +1,11 @@
 <div id="social-signin-links">
   <% if (!spree_current_user || !spree_current_user.user_authentications) && Spree::AuthenticationMethod.active_authentication_methods? %>
-    <h2><%= Spree.t(:sign_in_through_one_of_these_services) %></h2>
+    <h2><%= I18n.t('spree.sign_in_through_one_of_these_services') %></h2>
   <% end %>
-  
+
   <% Spree::AuthenticationMethod.available_for(spree_current_user).each do |method| %>
     <%= link_to(content_tag(:i, '', class: "icon-spree-#{method.provider.dasherize}-circled"),
           spree.send("spree_user_#{method.provider}_omniauth_authorize_path"),
-          title: Spree.t(:sign_in_with, provider: method.provider)) if method.active %>
+          title: I18n.t('spree.sign_in_with', provider: method.provider)) if method.active %>
   <% end %>
 </div>

--- a/app/views/spree/shared/_user_form.html.erb
+++ b/app/views/spree/shared/_user_form.html.erb
@@ -1,16 +1,16 @@
 <p>
-  <%= f.label :email, Spree.t(:email) %><br />
+  <%= f.label :email, I18n.t('spree.email') %><br />
   <%= f.email_field :email, class: 'title' %>
 </p>
 <% if spree_current_user.nil? || spree_current_user.password_required? %>
   <div id="password-credentials">
     <p>
-      <%= f.label :password, Spree.t(:password) %><br />
+      <%= f.label :password, I18n.t('spree.password') %><br />
       <%= f.password_field :password, class: 'title' %>
     </p>
 
     <p>
-      <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
+      <%= f.label :password_confirmation, I18n.t('spree.confirm_password') %><br />
       <%= f.password_field :password_confirmation, class: 'title' %>
     </p>
   </div>

--- a/app/views/spree/users/_new-customer.html.erb
+++ b/app/views/spree/users/_new-customer.html.erb
@@ -1,5 +1,5 @@
 <% if session[:omniauth] %>
-  <h6><%= Spree.t(:please_confirm_your_email) %></h6>
+  <h6><%= I18n.t('spree.please_confirm_your_email') %></h6>
 <% else %>
-  <h6><%= Spree.t(:new_customer) %></h6>
+  <h6><%= I18n.t('spree.new_customer') %></h6>
 <% end %>

--- a/app/views/spree/users/_social.html.erb
+++ b/app/views/spree/users/_social.html.erb
@@ -3,7 +3,7 @@
   <div id="existing-customer">
     <% if spree_current_user.user_authentications %>
       <% unless spree_current_user.user_authentications.empty? %>
-        <p><strong><%= Spree.t(:you_have_signed_in_with_these_services) %>:</strong></p>
+        <p><strong><%= I18n.t('spree.you_have_signed_in_with_these_services') %>:</strong></p>
         <div class="authentications">
           <% for user_authentication in spree_current_user.user_authentications %>
             <div class="authentication">
@@ -12,16 +12,16 @@
                 <%= user_authentication.provider %>
               </div>
               <div class="uid columns two"><%= user_authentication.uid %></div>
-              <%= link_to 'X', user_authentication, data: { confirm: "#{Spree.t(:remove_authentication_option_confirmation)}" }, method: :delete, class: 'remove' %>
+              <%= link_to 'X', user_authentication, data: { confirm: I18n.t('spree.remove_authentication_option_confirmation') }, method: :delete, class: 'remove' %>
             </div>
           <% end %>
           <div class="clear"></div>
         </div>
       <% end %>
     <% end %>
-    
+
     <% if Spree::AuthenticationMethod.available_for(spree_current_user).present? %>
-      <%= content_tag(:p, content_tag(:strong, Spree.t(:add_another_service))) %>
+      <%= content_tag(:p, content_tag(:strong, I18n.t('spree.add_another_service'))) %>
       <%= render 'spree/shared/social' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
       destroy: 'Successfully destroyed authentication method.'
     back_to_authentication_methods_list: "Back To Authentication Methods List"
     edit_social_method: "Editing Social Authentication Method"
+    environment: "Environment"
     new_social_method: "New Authentication Method"
     no_authentication_methods_found: "No Authentication Methods Found"
     one_more_step: 'One more step to complete your registration from %{kind}'

--- a/solidus_social.gemspec
+++ b/solidus_social.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'database_cleaner', '~> 1.6'
   s.add_development_dependency 'rspec-rails', '~> 3.7'
-  s.add_development_dependency 'factory_bot', '~> 4.4'
   s.add_development_dependency 'selenium-webdriver', '>= 2.41.0'
   s.add_development_dependency 'chromedriver-helper'
   s.add_development_dependency 'poltergeist', '~> 1.5'


### PR DESCRIPTION
This PR aims to:

* Fix `Spree.t` deprecation warnings
* Add a missing I18n key called "maintenance" that was causing two (2) specs to fail when `Spree.t` was replaced with `I18n.t`
* Remove support for Solidus v2.2 on CI (EOL)
* Lock FactoryBot to v4.10 for Solidus versions lower than 2.5 for compatibility reasons
* Create symlink to add ChromeDriver to Travis `$PATH` to take advantage of Headless Chrome