### PR TITLE
Fixes for Spanish locale ES

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,5 @@
 ---
-es-MX:
+es:
   authentications:
     spree:
       destroy: Método de autenticación eliminado


### PR DESCRIPTION
Hello

Just checking this extension was missing the `es.yml` for Spanish. It has already the `es-MX.yml` which is fine but my stores are setup to use `es` and not the Mexican variation.

Also I fixed a typo and add a missing translation key for the `es-MX.yml` file.

So any other Spanish speaker here who could validate this is welcome.

Regards