### PR TITLE
Spree::PermissionSets for AuthenticationMethod

### DIFF
--- a/app/core/spree/permission_sets/authentication_method_display.rb
+++ b/app/core/spree/permission_sets/authentication_method_display.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PermissionSets
+    class AuthenticationMethodDisplay < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::AuthenticationMethod
+      end
+    end
+  end
+end

--- a/app/core/spree/permission_sets/authentication_method_management.rb
+++ b/app/core/spree/permission_sets/authentication_method_management.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PermissionSets
+    class AuthenticationMethodManagement < PermissionSets::Base
+      def activate!
+        can :manage, Spree::AuthenticationMethod
+      end
+    end
+  end
+end

--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -3,5 +3,10 @@
 Deface::Override.new(virtual_path: 'spree/admin/shared/_configuration_menu',
                      name: 'add_social_providers_link_configuration_menu',
                      insert_bottom: '[data-hook="admin_configurations_sidebar_menu"]',
-                     text: '<%= configurations_sidebar_menu_item I18n.t("spree.social_authentication_methods"), spree.admin_authentication_methods_path %>',
-                     disabled: false)
+                     disabled: false) do
+                       <<-HTML
+                        <% if can? :admin, Spree::AuthenticationMethod %>
+                          <%= configurations_sidebar_menu_item I18n.t("spree.social_authentication_methods"), spree.admin_authentication_methods_path %>
+                        <% end %>
+                        HTML
+                     end

--- a/app/views/spree/admin/authentication_methods/edit.html.erb
+++ b/app/views/spree/admin/authentication_methods/edit.html.erb
@@ -13,6 +13,8 @@
 <%= form_for [:admin, @authentication_method] do |f| %>
   <fieldset class="no-border-top">
     <%= render 'form', f: f %>
-    <%= render 'spree/admin/shared/edit_resource_links' %>
+    <% if can? :manage, Spree::AuthenticationMethod %>
+      <%= render 'spree/admin/shared/edit_resource_links' %>
+    <% end %>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/authentication_methods/index.html.erb
+++ b/app/views/spree/admin/authentication_methods/index.html.erb
@@ -5,11 +5,13 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <ul class="actions inline-menu">
-    <li>
-      <%= link_to I18n.t('spree.new_social_method'), new_object_url, id: 'admin_new_slide_link' %>
-    </li>
-  </ul>
+  <% if can? :manage, Spree::AuthenticationMethod %>
+    <ul class="actions inline-menu">
+      <li>
+        <%= link_to I18n.t('spree.new_social_method'), new_object_url, id: 'admin_new_slide_link' %>
+      </li>
+    </ul>
+  <% end %>
 <% end %>
 
 <% if @authentication_methods.any? %>
@@ -39,8 +41,10 @@
           <td class="align-center"><%= method.environment.to_s.titleize %></td>
           <td class="align-center"><%= method.active ? I18n.t('spree.yes') : I18n.t('spree.no') %></td>
           <td class="actions">
-            <%= link_to_edit method, no_text: true %>
-            <%= link_to_delete method, no_text: true %>
+            <% if can? :manage, Spree::AuthenticationMethod %>
+              <%= link_to_edit method, no_text: true %>
+              <%= link_to_delete method, no_text: true %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/spree/admin/authentication_methods/new.html.erb
+++ b/app/views/spree/admin/authentication_methods/new.html.erb
@@ -13,6 +13,8 @@
 <%= form_for [:admin, @authentication_method] do |f| %>
   <fieldset class="no-border-top">
     <%= render 'form', f: f %>
-    <%= render 'spree/admin/shared/new_resource_links' %>
+    <% if can? :manage, Spree::AuthenticationMethod %>
+      <%= render 'spree/admin/shared/new_resource_links' %>
+    <% end %>
   </fieldset>
 <% end %>


### PR DESCRIPTION
Hello

I created a couple of permission sets for this extension in order to have more control of access on Authentication Methods for admin users. In that way we could have admin users to change the overall configuration and other admin users with access only for authentication methods themselves. It works along the Spree::PermissinSets classes and it could be integrated with the extension `https://github.com/boomerdigital/solidus_user_roles.`

Let me know what you think

Happy to fix if you guys spot something wrong.