### PR TITLE
Solidus 3.0

### DIFF
--- a/lib/solidus_social/engine.rb
+++ b/lib/solidus_social/engine.rb
@@ -12,7 +12,7 @@ require 'solidus_social/facebook_omniauth_strategy_ext'
 
 module SolidusSocial
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 

--- a/solidus_social.gemspec
+++ b/solidus_social.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth-google-oauth2'
   spec.add_dependency 'omniauth-twitter'
   spec.add_dependency 'solidus_auth_devise'
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '<= 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
No major changes needed. Only a single deprecation warning for SolidusSupport. (From https://github.com/solidusio/solidus_support/pull/42)

Fixes #87.