### PR TITLE
 Relax Ruby required version to support Ruby 3.0+

### DIFF
--- a/solidus_social.gemspec
+++ b/solidus_social.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_social'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_social/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.4')
+  spec.required_ruby_version = '>= 2.4'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This PR removes Ruby version upper limit in gemspec to make the gem work with Ruby 3.0