### PR TITLE
Fix autoload warnings during initialization

### DIFF
--- a/lib/solidus_social/config.rb
+++ b/lib/solidus_social/config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'solidus_social/social_configuration'
+
+module Spree
+  def self.social_config
+    @config ||= Spree::SocialConfiguration.new
+  end
+
+  def self.const_missing(name)
+    name == :SocialConfig ? social_config : super
+  end
+end

--- a/lib/solidus_social/engine.rb
+++ b/lib/solidus_social/engine.rb
@@ -7,7 +7,7 @@ require 'omniauth/twitter2'
 require 'omniauth/rails_csrf_protection'
 require 'deface'
 require 'spree/core'
-require 'solidus_social/social_configuration'
+require 'solidus_social/config'
 require 'solidus_social/facebook_omniauth_strategy_ext'
 
 module SolidusSocial


### PR DESCRIPTION
This fixes a deprecation warning about autoloading the `Spree::SocialConfiguration` constant during initialization. It also moves the config out of the `Spree::SocialConfig` constant and into a method while maintaining backwards compatibility per [this suggestion](https://github.com/solidusio/solidus_auth_devise/issues/189#issuecomment-618953960).

Autoloading constants like `Spree::SocialConfig` during initialization will break in Rails 7.

This is the original warning:

```
DEPRECATION WARNING: Initialization autoloaded the constant Spree::SocialConfiguration.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Spree::ReviewsConfiguration, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```