### PR TITLE
Add coffee-rails dependency

### DIFF
--- a/solidus_social.gemspec
+++ b/solidus_social.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'coffee-rails'
   spec.add_dependency 'deface'
   spec.add_dependency 'oa-core'
   spec.add_dependency 'omniauth'


### PR DESCRIPTION
Before this PR the gem failed with:

```
cannot load such file -- coffee_script (LoadError)
```