### PR TITLE
Update Omniauth version to 2.0 or greater

### DIFF
--- a/app/views/spree/shared/_social.html.erb
+++ b/app/views/spree/shared/_social.html.erb
@@ -4,8 +4,12 @@
   <% end %>
 
   <% Spree::AuthenticationMethod.available_for(spree_current_user).each do |method| %>
-    <%= link_to(content_tag(:i, '', class: "icon-spree-#{method.provider.dasherize}-circled"),
-          spree.send("spree_user_#{method.provider}_omniauth_authorize_path", r: rand),
-          title: t('spree.sign_in_with', provider: method.provider)) if method.active %>
+    <% if method.active %>
+      <%= form_tag(spree.send("spree_user_#{method.provider}_omniauth_authorize_path", r: rand), method: 'post') do %>
+        <%= button_tag(type: 'submit', title: t('spree.sign_in_with', provider: method.provider)) do %>
+          <%= content_tag(:i, '', class: "icon-spree-#{method.provider.dasherize}-circled") %>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/lib/generators/solidus_social/install/templates/config/initializers/solidus_social.rb
+++ b/lib/generators/solidus_social/install/templates/config/initializers/solidus_social.rb
@@ -36,7 +36,6 @@ OmniAuth.logger.progname = 'omniauth'
 
 OmniAuth.config.on_failure = proc do |env|
   env['devise.mapping'] = Devise.mappings[Spree.user_class.table_name.singularize.to_sym]
-  controller_name = ActiveSupport::Inflector.camelize(env['devise.mapping'].controllers[:omniauth_callbacks])
-  controller_klass = ActiveSupport::Inflector.constantize("#{controller_name}Controller")
+  controller_klass = ActiveSupport::Inflector.constantize("Spree::OmniauthCallbacksController")
   controller_klass.action(:failure).call(env)
 end

--- a/lib/solidus_social/engine.rb
+++ b/lib/solidus_social/engine.rb
@@ -3,6 +3,7 @@
 require 'omniauth-facebook'
 require 'omniauth-github'
 require 'omniauth-google-oauth2'
+require 'omniauth/rails_csrf_protection'
 require 'deface'
 require 'spree/core'
 require 'solidus_social/social_configuration'

--- a/solidus_social.gemspec
+++ b/solidus_social.gemspec
@@ -30,10 +30,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deface'
   spec.add_dependency 'oa-core'
-  spec.add_dependency 'omniauth', '~> 1.9.1'
+  spec.add_dependency 'omniauth'
   spec.add_dependency 'omniauth-facebook'
   spec.add_dependency 'omniauth-github'
   spec.add_dependency 'omniauth-google-oauth2'
+  spec.add_dependency 'omniauth-rails_csrf_protection'
   spec.add_dependency 'solidus_auth_devise'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'

--- a/spec/features/spree/sign_in_spec.rb
+++ b/spec/features/spree/sign_in_spec.rb
@@ -52,4 +52,108 @@ RSpec.describe 'Signing in using Omniauth', :js do
       expect(page).not_to have_selector 'div#social-signin-links'
     end
   end
+
+  context 'github' do
+    before do
+      Spree::AuthenticationMethod.create!(
+        provider: 'github',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true
+      )
+      OmniAuth.config.mock_auth[:github] = {
+        'provider' => 'github',
+        'uid' => '123545',
+        'info' => {
+          'name' => 'mockuser',
+          'email' => 'mockuser@example.com',
+          'image' => 'mock_user_thumbnail_url'
+        },
+        'credentials' => {
+          'token' => 'mock_token',
+          'secret' => 'mock_secret'
+        }
+      }
+    end
+
+    it 'going to sign in' do
+      visit spree.login_path
+      click_on 'Login with github'
+      expect(page).to have_text 'You are now signed in with your github account.'
+      click_link 'Logout'
+      click_link 'Login'
+      click_on 'Login with github'
+      expect(page).to have_text 'You are now signed in with your github account.'
+    end
+
+    # Regression test for #91
+    it "attempting to view 'My Account' works" do
+      visit spree.login_path
+      click_on 'Login with github'
+      expect(page).to have_text 'You are now signed in with your github account.'
+      click_link 'My Account'
+      expect(page).to have_text 'My Account'
+    end
+
+    it "view 'My Account'" do
+      visit spree.login_path
+      click_on 'Login with github'
+      expect(page).to have_text 'You are now signed in with your github account.'
+      click_link 'My Account'
+      expect(page).not_to have_selector 'div#social-signin-links'
+    end
+  end
+
+  context 'google_oauth2' do
+    before do
+      Spree::AuthenticationMethod.create!(
+        provider: 'google_oauth2',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true
+      )
+      OmniAuth.config.mock_auth[:google_oauth2] = {
+        'provider' => 'google_oauth2',
+        'uid' => '123545',
+        'info' => {
+          'name' => 'mockuser',
+          'email' => 'mockuser@example.com',
+          'image' => 'mock_user_thumbnail_url'
+        },
+        'credentials' => {
+          'token' => 'mock_token',
+          'secret' => 'mock_secret'
+        }
+      }
+    end
+
+    it 'going to sign in' do
+      visit spree.login_path
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+      click_link 'Logout'
+      click_link 'Login'
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+    end
+
+    # Regression test for #91
+    it "attempting to view 'My Account' works" do
+      visit spree.login_path
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+      click_link 'My Account'
+      expect(page).to have_text 'My Account'
+    end
+
+    it "view 'My Account'" do
+      visit spree.login_path
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+      click_link 'My Account'
+      expect(page).not_to have_selector 'div#social-signin-links'
+    end
+  end
 end


### PR DESCRIPTION
This aims to update the gem to support Omniauth version 2.0 or greater which has introduced breaking changes from the previous version of omniauth 1.9.1

@waiting-for-dev @DanielePalombo

https://github.com/solidusio-contrib/solidus_social/issues/104#issuecomment-1217814727