### PR TITLE
Utilize Devise Location helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea
 .project
 .sass-cache
+sandbox
 coverage
 Gemfile.lock
 tmp

--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def omniauth_callback
     if request.env['omniauth.error'].present?
       flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: auth_hash['provider'], reason: I18n.t('spree.user_was_not_valid'))
-      redirect_back_or_default(root_url)
+      redirect_to stored_spree_user_location_or(root_url)
       return
     end
 
@@ -34,7 +34,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       spree_current_user.apply_omniauth(auth_hash)
       spree_current_user.save!
       flash[:notice] = I18n.t('devise.sessions.signed_in')
-      redirect_back_or_default(account_url)
+      redirect_to stored_spree_user_location_or(account_url)
     else
       user = Spree.user_class.find_by(email: auth_hash['info']['email']) || Spree.user_class.new
       user.apply_omniauth(auth_hash)

--- a/spec/controllers/spree/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/spree/omniauth_callbacks_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spree::OmniauthCallbacksController, type: :controller do
     Rails.application.routes.default_url_options[:host] = 'test.host'
     request.env['omniauth.auth'] = omni_params
     allow(controller).to receive(:sign_in_and_redirect)
-    allow(controller).to receive(:redirect_back_or_default)
+    allow(controller).to receive(:redirect_to)
     allow(Spree::User).to receive(:anonymous!).with(user)
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Spree::OmniauthCallbacksController, type: :controller do
     before { request.env['omniauth.error'] = 'FAIL' }
 
     it 'redirects properly' do
-      expect(controller).to receive(:redirect_back_or_default)
+      expect(controller).to receive(:redirect_to)
       controller.github
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Spree::OmniauthCallbacksController, type: :controller do
         end
 
         it 'redirects properly' do
-          expect(controller).to receive(:redirect_back_or_default)
+          expect(controller).to receive(:redirect_to)
           controller.github
         end
 


### PR DESCRIPTION
Description
Removes `#redirect_back_or_default` in favor of `solidus_auth_devise` helper methods

Motivation and Context
The method `#redirect_back_or_default` and the class `user_last_url_storer` will be deprecated in Solidus https://github.com/solidusio/solidus/pull/4533 which would break the current build without these changes. SolidusAuthDevise has similar a helper method to #redirect_back_or_default, `#stored_spree_user_location_or` which was introduced in https://github.com/solidusio/solidus_auth_devise/pull/228 and will be utilized instead.

How Has This Been Tested?
The current test suite covers the changes made in the PR
