### PR TITLE
Add Multi-Store Support to Authentication Methods

### DIFF
--- a/app/controllers/spree/admin/authentication_methods_controller.rb
+++ b/app/controllers/spree/admin/authentication_methods_controller.rb
@@ -3,6 +3,8 @@
 module Spree
   module Admin
     class AuthenticationMethodsController < ResourceController
+      private
+
       def build_resource
         model_class.new(
           store_ids: [Spree::Store.default.id].compact

--- a/app/controllers/spree/admin/authentication_methods_controller.rb
+++ b/app/controllers/spree/admin/authentication_methods_controller.rb
@@ -3,6 +3,11 @@
 module Spree
   module Admin
     class AuthenticationMethodsController < ResourceController
+      def build_resource
+        model_class.new(
+          store_ids: [Spree::Store.default.id].compact
+        )
+      end
     end
   end
 end

--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -19,6 +19,8 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     provides_callback_for provider.key.to_sym
   end
 
+  after_action :set_current_order, only: SolidusSocial::OAUTH_PROVIDERS.map(&:key)
+
   def omniauth_callback
     if request.env['omniauth.error'].present?
       flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: auth_hash['provider'], reason: I18n.t('spree.user_was_not_valid'))

--- a/app/decorators/models/solidus_social/spree/store_decorator.rb
+++ b/app/decorators/models/solidus_social/spree/store_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidusSocial
+  module Spree
+    module StoreDecorator
+      def self.prepended(base)
+        base.class_eval do
+          has_many :store_authentication_methods, class_name: 'Spree::StoreAuthenticationMethod'
+          has_many :authentication_methods, through: :store_authentication_methods, class_name: 'Spree::AuthenticationMethod'
+        end
+      end
+
+      ::Spree::Store.prepend self
+    end
+  end
+end

--- a/app/helpers/spree/admin/authentication_methods_helper.rb
+++ b/app/helpers/spree/admin/authentication_methods_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module AuthenticationMethodsHelper
+      def available_authentication_methods(current_store, spree_current_user)
+        Spree::AuthenticationMethod
+          .available_to_store(current_store)
+          .available_for(spree_current_user)
+      end
+
+      def available_stores
+        @available_stores ||= Spree::Store.accessible_by(current_ability)
+      end
+    end
+  end
+end

--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -3,6 +3,9 @@
 class Spree::AuthenticationMethod < ActiveRecord::Base
   validates :provider, :api_key, :api_secret, presence: true
 
+  has_many :store_authentication_methods, inverse_of: :authentication_method
+  has_many :stores, through: :store_authentication_methods
+
   def self.active_authentication_methods?
     where(environment: ::Rails.env, active: true).exists?
   end
@@ -12,6 +15,12 @@ class Spree::AuthenticationMethod < ActiveRecord::Base
     sc = sc.where.not(provider: user.user_authentications.pluck(:provider)) if user && !user.user_authentications.empty?
     sc
   }
+
+  scope :available_to_store, ->(store) do
+    raise ArgumentError, "You must provide a store" if store.nil?
+
+    store.authentication_methods.empty? ? all : where(id: store.authentication_method_ids)
+  end
 
   def provider_name
     provider = SolidusSocial::OAUTH_PROVIDERS.find { |oauth_provider| oauth_provider.key == self.provider }

--- a/app/models/spree/store_authentication_method.rb
+++ b/app/models/spree/store_authentication_method.rb
@@ -1,0 +1,11 @@
+module Spree
+  class StoreAuthenticationMethod < ActiveRecord::Base
+    self.table_name = 'spree_authentication_methods_stores'
+
+    belongs_to :store, class_name: 'Spree::Store', touch: true
+    belongs_to :authentication_method, class_name: 'Spree::AuthenticationMethod', touch: true
+
+    validates :store, :authentication_method, presence: true
+    validates :store_id, uniqueness: { scope: :authentication_method_id }
+  end
+end

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -36,6 +36,24 @@
     </div>
   </div>
 
+  <% if can?(:manage, Spree::Store) && available_stores.count > 1 %>
+    <div class="row">
+      <div class="col-12 col-lg-6">
+        <div data-hook="stores" class="field">
+          <%= f.field_container :stores do %>
+            <%= label_tag :authentication_method_stores, I18n.t('spree.stores') %>
+            <%= f.collection_check_boxes :store_ids, available_stores, :id, :name do |b| %>
+              <div class="custom-control custom-checkbox mb-1">
+                <%= b.check_box(class: 'custom-control-input') %>
+                <%= b.label(class: 'custom-control-label') %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="row">
     <div class="col-12 col-lg-6">
       <div data-hook="environment" class="field">

--- a/app/views/spree/shared/_social.html.erb
+++ b/app/views/spree/shared/_social.html.erb
@@ -1,15 +1,17 @@
-<div id="social-signin-links">
-  <% if (!spree_current_user || !spree_current_user.user_authentications) && Spree::AuthenticationMethod.active_authentication_methods? %>
+<div id="social-signin-links" class="text-center">
+  <% if (!spree_current_user || !spree_current_user.user_authentications) && Spree::AuthenticationMethod.available_to_store(current_store).active_authentication_methods? %>
     <h2><%= I18n.t('spree.sign_in_through_one_of_these_services') %></h2>
   <% end %>
 
-  <% Spree::AuthenticationMethod.available_for(spree_current_user).each do |method| %>
-    <% if method.active %>
-      <%= form_tag(spree.send("spree_user_#{method.provider}_omniauth_authorize_path", r: rand), method: 'post') do %>
-        <%= button_tag(type: 'submit', title: t('spree.sign_in_with', provider: method.provider)) do %>
-          <%= content_tag(:i, '', class: "icon-spree-#{method.provider.dasherize}-circled") %>
-        <% end %>
+  <div class="flex justify-center">
+    <% available_authentication_methods(current_store, spree_current_user).each do |method| %>
+      <% if method.active %>
+          <%= form_tag(spree.send("spree_user_#{method.provider}_omniauth_authorize_path", r: rand), method: 'post') do %>
+            <%= button_tag(type: 'submit', title: t('spree.sign_in_with', provider: method.provider)) do %>
+              <%= content_tag(:i, '', class: "icon-spree-#{method.provider.dasherize}-circled") %>
+            <% end %>
+          <% end %>
       <% end %>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/spree/starter_frontend/shared/_social.html.erb
+++ b/app/views/spree/starter_frontend/shared/_social.html.erb
@@ -1,5 +1,5 @@
 <div id="social-signin-links" class="text-center">
-  <% if (!spree_current_user || !spree_current_user.user_authentications) && Spree::AuthenticationMethod.active_authentication_methods? %>
+  <% if (!spree_current_user || !spree_current_user.user_authentications) && Spree::AuthenticationMethod.available_to_store(current_store).active_authentication_methods? %>
     <div class="flex items-center my-4">
       <hr class="w-full h-px bg-gray-200 border-0 dark:bg-gray-700">
       <span class="px-3 text-gray-900 font-medium dark:text-white dark:bg-gray-900"><%= I18n.t('spree.or') %></span>
@@ -8,7 +8,7 @@
   <% end %>
 
   <div class="flex flex-col items-center w-full space-y-4">
-    <% Spree::AuthenticationMethod.available_for(spree_current_user).each do |method| %>
+    <% available_authentication_methods(current_store, spree_current_user).each do |method| %>
       <% if method.active %>
         <%= form_tag(spree.send("spree_user_#{method.provider}_omniauth_authorize_path", r: rand), method: 'post', class: "w-full") do %>
           <%= button_tag(type: 'submit', title: t('spree.sign_in_with', provider: method.provider_name), class: "w-full px-7 rounded-full text-body-sm font-bold leading-none uppercase whitespace-nowrap transiton-colors duration-200 border text-white flex items-center justify-between") do %>

--- a/app/views/spree/users/_social.html.erb
+++ b/app/views/spree/users/_social.html.erb
@@ -1,4 +1,4 @@
-<% if Spree::AuthenticationMethod.active_authentication_methods? %>
+<% if Spree::AuthenticationMethod.available_to_store(current_store).active_authentication_methods? %>
   <% @body_id = 'login' %>
   <div id="existing-customer">
     <% if spree_current_user.user_authentications %>
@@ -20,7 +20,7 @@
       <% end %>
     <% end %>
 
-    <% if Spree::AuthenticationMethod.available_for(spree_current_user).present? %>
+    <% if available_authentication_methods(current_store, spree_current_user).present? %>
       <%= content_tag(:p, content_tag(:strong, I18n.t('spree.add_another_service'))) %>
       <%= render 'spree/shared/social' %>
     <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,4 +23,5 @@ de:
     social_provider: "Social Anbieter"
     please_confirm_your_email: "Bitte bestätige deine Emailadresse um fortzufahren"
     sign_in_with: "Mit %{provider} einloggen"
+    stores: "Geschäfte"
     you_have_signed_in_with_these_services: "Sie haben mit diesen Diensten unterzeichnet"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,4 +23,5 @@ en:
     social_provider: "Social Provider"
     please_confirm_your_email: "Please confirm your email address to continue"
     sign_in_with: "Login with %{provider}"
+    stores: "Stores"
     you_have_signed_in_with_these_services: "You Have Signed In With These Services"

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -26,5 +26,6 @@ es-MX:
     social_provider: 'Proveedor social'
     please_confirm_your_email: 'Por favor confirme su email para continuar'
     sign_in_with: 'Autenticado con %{provider}'
+    stores: "Tiendas"
     you_have_signed_in_with_these_services: "Has iniciado sesión con estos servicios"
     environment: Ambiente

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -26,5 +26,6 @@ es:
     social_provider: 'Proveedor social'
     please_confirm_your_email: 'Por favor confirme su email para continuar'
     sign_in_with: 'Autenticado con %{provider}'
+    stores: "Tiendas"
     you_have_signed_in_with_these_services: "Has iniciado sesión con estos servicios"
     environment: Ambiente

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,4 +23,5 @@ fr:
     social_provider: "Réseau Social"
     please_confirm_your_email: "Confirmez votre adresse courriel avant de continuer"
     sign_in_with: "Identification via %{provider}"
+    stores: "Magasins"
     you_have_signed_in_with_these_services: "Vous avez signé avec ces services"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -23,4 +23,5 @@ it:
     social_provider: "Social Provider"
     please_confirm_your_email: "Per favore, conferma il tuo indirizzo e-mail per continuare."
     sign_in_with: "Login con %{provider}"
+    stores: "Negozi"
     you_have_signed_in_with_these_services: "Hai fatto log-in con questi servizi"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -23,4 +23,5 @@ nl:
     social_provider: 'Social Provider'
     please_confirm_your_email: 'Bevestig je email adres om verder te gaan'
     sign_in_with: 'Login met %{provider}'
+    stores: "Winkels"
     you_have_signed_in_with_these_services: "Je hebt in deze diensten ondertekend"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,4 +23,5 @@ pt-BR:
     social_provider: "Provedor Social"
     please_confirm_your_email: "Por favor confirme seu endereço de e-mail para continuar"
     sign_in_with: "Login com %{provider}"
+    stores: "Lojas"
     you_have_signed_in_with_these_services: "Você se cadastrou com estes serviços"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -23,4 +23,5 @@ sv:
     social_provider: "Social tjänst"
     please_confirm_your_email: "Bekräfta din e-postadress för att fortsätta"
     sign_in_with: "Logga in med %{provider}"
+    stores: "Butiker"
     you_have_signed_in_with_these_services: "Du har loggat in via dessa tjänster"

--- a/db/migrate/20250125164151_create_spree_authentication_methods_stores.rb
+++ b/db/migrate/20250125164151_create_spree_authentication_methods_stores.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSpreeAuthenticationMethodsStores < SolidusSupport::Migration[4.2]
+  def change
+    create_table :spree_authentication_methods_stores, id: false do |t|
+      t.belongs_to :authentication_method
+      t.belongs_to :store
+    end
+
+    add_index :spree_authentication_methods_stores, [:authentication_method_id, :store_id], unique: true, name: 'authentication_method_id_store_id_unique_index'
+  end
+end

--- a/lib/solidus_social/engine.rb
+++ b/lib/solidus_social/engine.rb
@@ -19,11 +19,14 @@ module SolidusSocial
     engine_name 'solidus_social'
 
     initializer 'solidus_social.environment', before: 'spree.environment' do
-      AUTHENTICATION_METHOD_PATH = config.root.join(
-        "app/models/spree/authentication_method.rb"
-      ).to_s
+      # Define file paths for loading resources
+      helpers_path = config.root.join('app/helpers/spree/admin/authentication_methods_helper.rb')
+      authentication_method_path = config.root.join('app/models/spree/authentication_method.rb')
 
-      load AUTHENTICATION_METHOD_PATH
+      # Load required files
+      [helpers_path, authentication_method_path].each do |path|
+        load path
+      end
     end
 
     USER_DECORATOR_PATH = root.join(
@@ -37,6 +40,12 @@ module SolidusSocial
         # Reload and decorate the spree user class immediately after it is
         # unloaded so that it is available to devise when loading routes
         load USER_DECORATOR_PATH
+      end
+    end
+
+    initializer 'solidus_social.include_helpers' do
+      ActiveSupport.on_load(:action_view) do
+        include Spree::Admin::AuthenticationMethodsHelper
       end
     end
 

--- a/spec/features/spree/sign_in_spec.rb
+++ b/spec/features/spree/sign_in_spec.rb
@@ -190,4 +190,73 @@ RSpec.describe 'Signing in using Omniauth', :js do
       expect(page).to have_text 'Welcome! You have signed up successfully.'
     end
   end
+
+  context 'Merge guest user cart with authenticated one' do
+    before do
+      Spree::AuthenticationMethod.create!(
+        provider: 'google_oauth2',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true
+      )
+      OmniAuth.config.mock_auth[:google_oauth2] = {
+        'provider' => 'google_oauth2',
+        'uid' => '123545',
+        'info' => {
+          'name' => 'mockuser',
+          'email' => 'mockuser@example.com',
+          'image' => 'mock_user_thumbnail_url'
+        },
+        'credentials' => {
+          'token' => 'mock_token',
+          'secret' => 'mock_secret'
+        }
+      }
+
+      # Create a default store
+      Spree::Store.create!(
+        name: 'Default Store',
+        code: 'default',
+        url: 'www.example.com',
+        mail_from_address: 'store@example.com',
+        default_currency: 'USD',
+        default: true
+      )
+
+      # Create a product
+      @product = create(:product)
+    end
+
+    it 'merges guest and user orders after login' do
+      # Step 1: Login and create an order with quantity 1
+      visit spree.login_path
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+
+      # Add a product to the cart with quantity 1
+      visit spree.product_path(@product)
+      find('#add-to-cart-button').click
+
+      user_order = Spree::Order.last
+      expect(user_order.item_count).to eq(1)
+      # Logout
+      click_link 'Logout'
+
+      # Step 2: As a guest, add a product to the cart with quantity 2
+      visit spree.product_path(@product)
+      fill_in 'quantity', with: 2
+      find('#add-to-cart-button').click
+
+      guest_order = Spree::Order.last
+      expect(guest_order.item_count).to eq(2)
+
+      # Step 3: Login again and verify the order is merged
+      visit spree.login_path
+      click_on 'Login with google_oauth2'
+      expect(page).to have_text 'You are now signed in with your google_oauth2 account.'
+      merged_order = Spree::Order.last
+      expect(merged_order.item_count).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
## Description:
This PR introduces multi-store support for authentication methods in Solidus. The enhancement allows users to configure authentication methods for multiple stores, providing greater flexibility while maintaining compatibility with authentication providers that support multiple redirect URIs.

## Key Features:
**1. Shared Credentials Across Stores:**
  - Authentication methods can now be shared across multiple stores, utilizing the same credentials.
  - Since most authentication providers (e.g., Facebook, Google, GitHub) allow multiple redirect URIs, requests will be redirected back to the originating store appropriately.
  
**2. Per-Store Configuration:**
 - Store administrators now have the option to configure unique authentication methods for individual stores if needed. This ensures flexibility for different use cases.
 
**3. Access Control:**
 - The stores listed in the authentication methods configuration are scoped based on the current user’s ability:
 
 ## Use Case:
This feature is particularly useful in multi-store environments where:

 - Admins need to reuse the same authentication method across multiple stores.
 - Different stores require separate configurations for authentication.
 
 ## Issues Covered:
 1. #126
 2. #80 